### PR TITLE
Implemented `EnumerationArrayType`

### DIFF
--- a/src/Attributes/EnumerationArrayType.php
+++ b/src/Attributes/EnumerationArrayType.php
@@ -4,8 +4,8 @@ namespace Tnapf\JsonMapper\Attributes;
 
 use Attribute;
 use BackedEnum;
-use InvalidArgumentException;
 use ReflectionEnum;
+use Tnapf\JsonMapper\Exception\InvalidArgumentException;
 use Tnapf\JsonMapper\Exception\InvalidValueTypeException;
 
 #[Attribute(Attribute::TARGET_PROPERTY)]
@@ -20,7 +20,7 @@ class EnumerationArrayType implements BaseType
         public readonly bool $nullable = false
     ) {
         if (!enum_exists($this->enum)) {
-            throw new InvalidArgumentException('Enumeration does not exist or is invalid.');
+            throw new InvalidArgumentException("{$this->enum} does not exist.");
         }
 
         $this->reflector = new ReflectionEnum($this->enum);
@@ -57,7 +57,7 @@ class EnumerationArrayType implements BaseType
     public function convert(mixed $data): array
     {
         if (!is_array($data)) {
-            throw new InvalidValueTypeException('array', gettype($data));
+            throw InvalidValueTypeException::create('array', gettype($data));
         }
 
         if ($this->caseSensitive) {

--- a/src/Attributes/EnumerationArrayType.php
+++ b/src/Attributes/EnumerationArrayType.php
@@ -1,0 +1,80 @@
+<?php
+
+namespace Tnapf\JsonMapper\Attributes;
+
+use Attribute;
+use BackedEnum;
+use InvalidArgumentException;
+use ReflectionEnum;
+use Tnapf\JsonMapper\Exception\InvalidValueTypeException;
+
+#[Attribute(Attribute::TARGET_PROPERTY)]
+class EnumerationArrayType implements BaseType
+{
+    private ReflectionEnum $reflector;
+
+    public function __construct(
+        public readonly string $name,
+        public readonly string $enum,
+        public readonly bool $caseSensitive = true,
+        public readonly bool $nullable = false
+    ) {
+        if (!enum_exists($this->enum)) {
+            throw new InvalidArgumentException('Enumeration does not exist or is invalid.');
+        }
+
+        $this->reflector = new ReflectionEnum($this->enum);
+        if (!$this->reflector->isBacked()) {
+            throw new InvalidArgumentException('Non-backed enumerations cannot be mapped.');
+        }
+    }
+
+    public function isType(mixed $data): bool
+    {
+        if (!is_array($data)) {
+            return false;
+        }
+
+        $cases = $this->reflector->getCases();
+        foreach ($data as $item) {
+            foreach ($cases as $case) {
+                if ($case->getValue() === $item) {
+                    continue 2;
+                }
+            }
+
+            return false;
+        }
+
+        return true;
+    }
+
+    /**
+     * @throws InvalidValueTypeException
+     *
+     * @return array<array-key, BackedEnum|null>
+     */
+    public function convert(mixed $data): array
+    {
+        if (!is_array($data)) {
+            throw new InvalidValueTypeException('array', gettype($data));
+        }
+
+        if ($this->caseSensitive) {
+            return array_map($this->enum::tryFrom(...), $data);
+        }
+
+        return array_map(
+            function (mixed $item): ?BackedEnum {
+                foreach ($this->reflector->getCases() as $case) {
+                    if (strcasecmp($case->getBackingValue(), $item) === 0) {
+                        return $case->getValue();
+                    }
+                }
+
+                return null;
+            },
+            $data
+        );
+    }
+}

--- a/src/Attributes/EnumerationType.php
+++ b/src/Attributes/EnumerationType.php
@@ -24,7 +24,7 @@ class EnumerationType implements BaseType
         public readonly bool $nullable = false
     ) {
         if (!enum_exists($this->enum)) {
-            throw new InvalidArgumentException('Enumeration does not exist or is invalid.');
+            throw new InvalidArgumentException("{$this->enum} does not exist.");
         }
 
         $this->reflector = new ReflectionEnum($this->enum);

--- a/src/Attributes/EnumerationType.php
+++ b/src/Attributes/EnumerationType.php
@@ -3,50 +3,74 @@
 namespace Tnapf\JsonMapper\Attributes;
 
 use Attribute;
-use InvalidArgumentException;
+use BackedEnum;
 use ReflectionEnum;
 use ReflectionException;
-use UnitEnum;
+use Tnapf\JsonMapper\Exception\InvalidArgumentException;
+use Tnapf\JsonMapper\Exception\InvalidValueTypeException;
 
 #[Attribute(Attribute::TARGET_PROPERTY)]
 class EnumerationType implements BaseType
 {
+    /** @var class-string<BackedEnum> */
+    public readonly string $enum;
+
+    private ReflectionEnum $reflector;
+
+    /**
+     * @throws InvalidArgumentException
+     */
     public function __construct(
         public readonly string $name,
-        public readonly string $enum,
+        string $enum,
         public readonly bool $caseSensitive = true,
         public readonly bool $nullable = false
     ) {
+        $this->enum = $enum;
         if (!enum_exists($this->enum)) {
             throw new InvalidArgumentException('Enumeration does not exist or is invalid.');
+        }
+
+        $this->reflector = new ReflectionEnum($this->enum);
+        if (!$this->reflector->isBacked()) {
+            throw new InvalidArgumentException('Non-backed enumerations cannot be mapped.');
         }
     }
 
     /**
      * @throws ReflectionException
+     * @throws InvalidValueTypeException
      */
     public function isType(mixed $data): bool
     {
-        $isScalar = is_int($data) || is_string($data);
-        $isEnumValue = $data instanceof UnitEnum;
-
-        if (!$isScalar && !$isEnumValue) {
-            return false;
-        }
-
-        $reflector = new ReflectionEnum($this->enum);
-
-        $comparator = $this->caseSensitive ? strcmp(...) : strcasecmp(...);
-        foreach ($reflector->getCases() as $case) {
-            if ($isEnumValue && $case->getValue() === $data) {
-                return true;
-            }
-
-            if ($isScalar && $reflector->isBacked() && $comparator($case->getBackingValue(), $data) === 0) {
+        foreach ($this->reflector->getCases() as $case) {
+            if ($case->getValue() === $data) {
                 return true;
             }
         }
 
         return false;
+    }
+
+    /**
+     * @throws InvalidValueTypeException
+     */
+    public function convert(mixed $data): ?BackedEnum
+    {
+        if (!is_string($data) && !is_int($data)) {
+            throw InvalidValueTypeException::create('int or string', gettype($data));
+        }
+
+        if ($this->caseSensitive) {
+            return $this->enum::tryFrom($data);
+        }
+
+        foreach ($this->reflector->getCases() as $case) {
+            if (strcasecmp($case->getBackingValue(), $data) === 0) {
+                return $case->getValue();
+            }
+        }
+
+        return null;
     }
 }

--- a/src/Attributes/EnumerationType.php
+++ b/src/Attributes/EnumerationType.php
@@ -12,9 +12,6 @@ use Tnapf\JsonMapper\Exception\InvalidValueTypeException;
 #[Attribute(Attribute::TARGET_PROPERTY)]
 class EnumerationType implements BaseType
 {
-    /** @var class-string<BackedEnum> */
-    public readonly string $enum;
-
     private ReflectionEnum $reflector;
 
     /**
@@ -22,11 +19,10 @@ class EnumerationType implements BaseType
      */
     public function __construct(
         public readonly string $name,
-        string $enum,
+        public readonly string $enum,
         public readonly bool $caseSensitive = true,
         public readonly bool $nullable = false
     ) {
-        $this->enum = $enum;
         if (!enum_exists($this->enum)) {
             throw new InvalidArgumentException('Enumeration does not exist or is invalid.');
         }

--- a/src/Attributes/ObjectArrayType.php
+++ b/src/Attributes/ObjectArrayType.php
@@ -3,6 +3,7 @@
 namespace Tnapf\JsonMapper\Attributes;
 
 use Attribute;
+use Tnapf\JsonMapper\Exception\InvalidArgumentException;
 
 #[Attribute(Attribute::TARGET_PROPERTY | Attribute::IS_REPEATABLE)]
 class ObjectArrayType implements BaseType
@@ -12,6 +13,9 @@ class ObjectArrayType implements BaseType
         public readonly string $class,
         public readonly bool $nullable = false
     ) {
+        if (!class_exists($this->class)) {
+            throw new InvalidArgumentException("{$this->class} does not exist.");
+        }
     }
 
     public function isType(mixed $data): bool

--- a/src/Attributes/ObjectType.php
+++ b/src/Attributes/ObjectType.php
@@ -3,15 +3,22 @@
 namespace Tnapf\JsonMapper\Attributes;
 
 use Attribute;
+use Tnapf\JsonMapper\Exception\InvalidArgumentException;
 
 #[Attribute(Attribute::TARGET_PROPERTY | Attribute::IS_REPEATABLE)]
 class ObjectType implements BaseType
 {
+    /**
+     * @throws InvalidArgumentException
+     */
     public function __construct(
         public readonly string $name,
         public readonly string $class,
         public readonly bool $nullable = false,
     ) {
+        if (!class_exists($this->class)) {
+            throw new InvalidArgumentException("{$this->class} does not exist.");
+        }
     }
 
     public function isType(mixed $data): bool

--- a/src/Exception/InvalidArgumentException.php
+++ b/src/Exception/InvalidArgumentException.php
@@ -1,0 +1,9 @@
+<?php
+
+namespace Tnapf\JsonMapper\Exception;
+
+use Tnapf\JsonMapper\MapperException;
+
+class InvalidArgumentException extends MapperException
+{
+}

--- a/src/Exception/InvalidValueTypeException.php
+++ b/src/Exception/InvalidValueTypeException.php
@@ -1,0 +1,13 @@
+<?php
+
+namespace Tnapf\JsonMapper\Exception;
+
+use Tnapf\JsonMapper\MapperException;
+
+class InvalidValueTypeException extends MapperException
+{
+    public static function create(string $expected, string $actual): InvalidValueTypeException
+    {
+        return new InvalidValueTypeException(sprintf('Expected value of type %s, got %s', $expected, $actual));
+    }
+}

--- a/src/Mapper.php
+++ b/src/Mapper.php
@@ -9,6 +9,7 @@ use Tnapf\JsonMapper\Attributes\AnyType;
 use Tnapf\JsonMapper\Attributes\CaseConversionInterface;
 use Tnapf\JsonMapper\Attributes\BaseType;
 use Tnapf\JsonMapper\Attributes\BoolType;
+use Tnapf\JsonMapper\Attributes\EnumerationArrayType;
 use Tnapf\JsonMapper\Attributes\EnumerationType;
 use Tnapf\JsonMapper\Attributes\FloatType;
 use Tnapf\JsonMapper\Attributes\IntType;
@@ -102,11 +103,12 @@ class Mapper implements MapperInterface
                     );
                 }
 
+                if ($type instanceof EnumerationType || $type instanceof EnumerationArrayType) {
+                    $data = $type->convert($data);
+                }
+
                 if ($type->isType($data)) {
                     $validType = true;
-                    if ($type instanceof EnumerationType) {
-                        $data = $type->enum::tryFrom($data);
-                    }
 
                     break;
                 }
@@ -165,13 +167,35 @@ class Mapper implements MapperInterface
                 [$type];
 
             foreach ($types as $type) {
-                $this->attributes[$name][] = match ($type->getName()) {
+                $typeName = $type->getName();
+
+                if (enum_exists($typeName)) {
+                    $this->attributes[$name][] = new EnumerationType(
+                        name: $name,
+                        enum: $typeName,
+                        nullable: $type->allowsNull()
+                    );
+
+                    continue;
+                }
+
+                if (class_exists($typeName)) {
+                    $this->attributes[$name][] = new ObjectType(
+                        name: $name,
+                        class: $typeName,
+                        nullable: $type->allowsNull()
+                    );
+
+                    continue;
+                }
+
+                $this->attributes[$name][] = match ($typeName) {
                     'int' => new IntType(name: $name, nullable: $type->allowsNull()),
                     'bool' => new BoolType(name: $name, nullable: $type->allowsNull()),
                     'string' => new StringType(name: $name, nullable: $type->allowsNull()),
                     'array' => new AnyArray(name: $name, nullable: $type->allowsNull()),
                     'float' => new FloatType(name: $name, nullable: $type->allowsNull()),
-                    default => new ObjectType(name: $name, class: $type->getName(), nullable: $type->allowsNull()),
+                    default => throw new MapperException('Unknown property type.')
                 };
             }
         }

--- a/src/Mapper.php
+++ b/src/Mapper.php
@@ -4,6 +4,7 @@ namespace Tnapf\JsonMapper;
 
 use ReflectionAttribute;
 use ReflectionClass;
+use ReflectionException;
 use Tnapf\JsonMapper\Attributes\AnyArray;
 use Tnapf\JsonMapper\Attributes\AnyType;
 use Tnapf\JsonMapper\Attributes\CaseConversionInterface;
@@ -16,6 +17,8 @@ use Tnapf\JsonMapper\Attributes\IntType;
 use Tnapf\JsonMapper\Attributes\ObjectArrayType;
 use Tnapf\JsonMapper\Attributes\ObjectType;
 use Tnapf\JsonMapper\Attributes\StringType;
+use Tnapf\JsonMapper\Exception\InvalidArgumentException;
+use Tnapf\JsonMapper\Exception\InvalidValueTypeException;
 
 class Mapper implements MapperInterface
 {
@@ -73,6 +76,11 @@ class Mapper implements MapperInterface
         return $this?->caseConversion?->convertFromCase($name) ?? $name;
     }
 
+    /**
+     * @throws ReflectionException
+     * @throws MapperException
+     * @throws InvalidValueTypeException
+     */
     protected function doMapping(): object
     {
         $this->fillPropertyAttributes();
@@ -132,9 +140,13 @@ class Mapper implements MapperInterface
         return $this->instance;
     }
 
+    /**
+     * @throws MapperException
+     * @throws InvalidArgumentException
+     */
     protected function fillPropertyAttributes(): void
     {
-        if ($this->attributes !== []) {
+        if (!empty($this->attributes)) {
             return;
         }
 

--- a/tests/AttributeTest.php
+++ b/tests/AttributeTest.php
@@ -18,6 +18,7 @@ use Tnapf\JsonMapper\Attributes\IntType;
 use Tnapf\JsonMapper\Attributes\PrimitiveArrayType;
 use Tnapf\JsonMapper\Attributes\StringType;
 use Tnapf\JsonMapper\Exception\InvalidArgumentException;
+use Tnapf\JsonMapper\Exception\InvalidValueTypeException;
 use Tnapf\JsonMapper\Tests\Fakes\IssueCategory;
 use Tnapf\JsonMapper\Tests\Fakes\IssueState;
 use Tnapf\JsonMapper\Tests\Fakes\RolePermission;
@@ -25,7 +26,7 @@ use Tnapf\JsonMapper\Tests\Fakes\AttributeDuplication;
 
 class AttributeTest extends TestCase
 {
-    public function testAnyArray()
+    public function testAnyArray(): void
     {
         $anyArray = new AnyArray(name: 'anyArray');
 
@@ -33,7 +34,7 @@ class AttributeTest extends TestCase
         $this->assertFalse($anyArray->isType('test'));
     }
 
-    public function testAnyType()
+    public function testAnyType(): void
     {
         $anyType = new AnyType(name: 'anyType');
 
@@ -41,7 +42,7 @@ class AttributeTest extends TestCase
         $this->assertTrue($anyType->isType(1));
     }
 
-    public function testBoolType()
+    public function testBoolType(): void
     {
         $boolType = new BoolType(name: 'boolType');
 
@@ -50,7 +51,7 @@ class AttributeTest extends TestCase
         $this->assertFalse($boolType->isType('test'));
     }
 
-    public function testFloatType()
+    public function testFloatType(): void
     {
         $floatType = new FloatType(name: 'floatType');
 
@@ -58,7 +59,7 @@ class AttributeTest extends TestCase
         $this->assertFalse($floatType->isType('test'));
     }
 
-    public function testIntType()
+    public function testIntType(): void
     {
         $intType = new IntType(name: 'intType');
 
@@ -66,7 +67,7 @@ class AttributeTest extends TestCase
         $this->assertFalse($intType->isType('test'));
     }
 
-    public function testObjectArray()
+    public function testObjectArray(): void
     {
         $objectArray = new ObjectArrayType(name: 'objectArray', class: stdClass::class);
 
@@ -75,7 +76,15 @@ class AttributeTest extends TestCase
         $this->assertFalse($objectArray->isType('test'));
     }
 
-    public function testObjectType()
+    public function testObjectArrayThrowsIfClassDoesNotExist(): void
+    {
+        $this->expectException(InvalidArgumentException::class);
+        $this->expectExceptionMessage('NonExistentClass does not exist');
+
+        new ObjectArrayType(name: 'objectArray', class: 'NonExistentClass');
+    }
+
+    public function testObjectType(): void
     {
         $objectType = new ObjectType(name: 'objectType', class: stdClass::class);
 
@@ -83,7 +92,15 @@ class AttributeTest extends TestCase
         $this->assertFalse($objectType->isType('test'));
     }
 
-    public function testStringType()
+    public function testObjectTypeThrowsIfClassDoesNotExist(): void
+    {
+        $this->expectException(InvalidArgumentException::class);
+        $this->expectExceptionMessage('NonExistentClass does not exist');
+
+        new ObjectType(name: 'objectType', class: 'NonExistentClass');
+    }
+
+    public function testStringType(): void
     {
         $stringType = new StringType(name: 'stringType');
 
@@ -91,7 +108,7 @@ class AttributeTest extends TestCase
         $this->assertFalse($stringType->isType(1));
     }
 
-    public function testPrimitiveArray()
+    public function testPrimitiveArray(): void
     {
         foreach (PrimitiveType::cases() as $primitive) {
             $primitiveType = new PrimitiveArrayType(name: 'primitiveType', type: $primitive);
@@ -131,7 +148,7 @@ class AttributeTest extends TestCase
         $type = new EnumerationType('issueCategory', IssueCategory::class);
 
         $this->assertSame(IssueCategory::GENERAL, $type->convert('general'));
-        $this->assertSame(null, $type->convert('INVALID'));
+        $this->assertNull($type->convert('INVALID'));
     }
 
     public function testStringBackedEnumerationTypeCaseInsensitiveConversion(): void
@@ -140,8 +157,17 @@ class AttributeTest extends TestCase
 
         $this->assertSame(IssueCategory::GENERAL, $type->convert('GENERAL'));
         $this->assertSame(IssueCategory::BUG, $type->convert('Bug'));
-        $this->assertSame(null, $type->convert('test123'));
         $this->assertSame(IssueCategory::ENHANCEMENT, $type->convert('enhancement'));
+        $this->assertNull($type->convert('test123'));
+    }
+
+    public function testEnumerationTypeThrowsIfDataTypeIsInvalid(): void
+    {
+        $this->expectException(InvalidValueTypeException::class);
+        $this->expectExceptionMessage('Expected value of type int or string, got object');
+
+        $type = new EnumerationType('issueCategory', IssueCategory::class);
+        $type->convert(new stdClass());
     }
 
     public function testEnumerationTypeInvalidData(): void
@@ -161,6 +187,40 @@ class AttributeTest extends TestCase
         $this->assertFalse($type->isType(1));
     }
 
+    public function testEnumerationArrayTypeConversion(): void
+    {
+        $type = new EnumerationArrayType('permissions', RolePermission::class);
+
+        $this->assertSame([RolePermission::READ, RolePermission::WRITE], $type->convert([1, 2]));
+        $this->assertSame([null, RolePermission::UNRESTRICTED], $type->convert([5, 4]));
+    }
+
+    public function testEnumerationArrayTypeConversionCaseSensitive(): void
+    {
+        $type = new EnumerationArrayType('issueCategory', IssueCategory::class);
+
+        $this->assertSame([IssueCategory::GENERAL, IssueCategory::BUG], $type->convert(['general', 'bug']));
+        $this->assertSame([IssueCategory::ENHANCEMENT, null], $type->convert(['enhancement', 'INVALID']));
+        $this->assertSame([null], $type->convert(['Invalid']));
+    }
+
+    public function testEnumerationArrayTypeConversionCaseInsensitive(): void
+    {
+        $type = new EnumerationArrayType('issueCategory', IssueCategory::class, false);
+
+        $this->assertSame([IssueCategory::GENERAL, IssueCategory::ENHANCEMENT], $type->convert(['GENERAL', 'enhancement']));
+        $this->assertSame([IssueCategory::ENHANCEMENT, null], $type->convert(['enhancement', 'Invalid?']));
+    }
+
+    public function testEnumerationArrayTypeThrowsOnInvalidValueType(): void
+    {
+        $this->expectException(InvalidValueTypeException::class);
+        $this->expectExceptionMessage('Expected value of type array, got string');
+
+        $type = new EnumerationArrayType('issueCategory', IssueCategory::class);
+        $type->convert('general');
+    }
+
     public function testPureEnumerationTypeIsNotSupported(): void
     {
         $this->expectException(InvalidArgumentException::class);
@@ -169,7 +229,31 @@ class AttributeTest extends TestCase
         new EnumerationType('issueState', IssueState::class);
     }
 
-    public function testAttributeRepetitionOnProperty()
+    public function testPureEnumerationArrayTypeIsNotSupported(): void
+    {
+        $this->expectException(InvalidArgumentException::class);
+        $this->expectExceptionMessage('Non-backed enumerations cannot be mapped.');
+
+        new EnumerationArrayType('issueState', IssueState::class);
+    }
+
+    public function testEnumerationTypeThrowsIfEnumDoesNotExist(): void
+    {
+        $this->expectException(InvalidArgumentException::class);
+        $this->expectExceptionMessage('NonExistentEnum does not exist.');
+
+        new EnumerationType(name: 'enumerationType', enum: 'NonExistentEnum');
+    }
+
+    public function testEnumerationArrayThrowsIfEnumDoesNotExist(): void
+    {
+        $this->expectException(InvalidArgumentException::class);
+        $this->expectExceptionMessage('NonExistentEnum does not exist.');
+
+        new EnumerationArrayType(name: 'enumerationArray', enum: 'NonExistentEnum');
+    }
+
+    public function testAttributeRepetitionOnProperty(): void
     {
         $class = new ReflectionClass(AttributeDuplication::class);
         $property = $class->getProperty('property');

--- a/tests/Fakes/Role.php
+++ b/tests/Fakes/Role.php
@@ -2,13 +2,9 @@
 
 namespace Tnapf\JsonMapper\Tests\Fakes;
 
-use Tnapf\JsonMapper\Attributes\EnumerationType;
-
 class Role
 {
     public int $id;
     public string $name;
-
-    #[EnumerationType('permissions', RolePermission::class)]
     public RolePermission $permissions;
 }


### PR DESCRIPTION
- Implemented `EnumerationArrayType`;
- Dropped support for pure enumerations since it's not possible to get pure enumeration case from `json_decode()`;
- `EnumerationType::isType()` and `EnumerationArrayType::isType()` now consider non-case values as invalid (to comply with original `Mapper` logic);
- `Mapper` throws when it cannot infer data type from class reflection instead of defaulting to `ObjectType`.
